### PR TITLE
Fix #13: Dropbox storage failed

### DIFF
--- a/js/dropbox.js
+++ b/js/dropbox.js
@@ -24,6 +24,10 @@ $(document).ready(function () {
 				} else {
 					var client_id = $tr.find('.configuration [data-parameter="client_id"]').val();
 					var client_secret = $tr.find('.configuration [data-parameter="client_secret"]').val();
+					if (localStorage.getItem('files_external_dropbox_oauth2')) {
+						client_secret = atob(localStorage.getItem('files_external_dropbox_oauth2'));
+						localStorage.removeItem('files_external_dropbox_oauth2');
+					}
 
 					var params = {};
 					window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
@@ -126,6 +130,7 @@ OCA.Files_External.Settings.OAuth2.getDropboxAuthUrl = function (backendUrl, dat
 							t('files_external', 'No URL provided by backend ' + data['backend_id'])
 						);
 					} else {
+						localStorage.setItem('files_external_dropbox_oauth2', btoa(data['client_secret']));
 						window.location = result.data.url;
 					}
 				});


### PR DESCRIPTION
This commits fixes #13: "Exception: Creating \OCA\Files_external_dropbox\Storage\Dropbox storage failed".
With this fix the plugin is compatible with Nextcloud 19.

The problem was:
- With commit (https://github.com/nextcloud/server/commit/0d112d7901983a568f6a803f59f240afd434db61#diff-8b87ec33b8bfb6e79af3a46d287408d2) the client_secret was rewrite after reload (or backlink from oauth2) to "\_\_unmodified__"
- To fix this behavior this commit saves client_secret temporary in localstorage
- After reading from localstorage the client_secret would be deleted

Additionally:
- If an user selects dropbox and onedrive or google drive: The plugins overwritten each other's events.